### PR TITLE
auto select subplebbit on post if routed from subplebbit

### DIFF
--- a/src/components/Post/CreatePost/createPostBar.jsx
+++ b/src/components/Post/CreatePost/createPostBar.jsx
@@ -5,7 +5,7 @@ import { LinkIcon } from '@chakra-ui/icons';
 import { ProfileContext } from '../../../store/profileContext';
 import Avatar from '../../Avatar';
 
-const CreatePostBar = () => {
+const CreatePostBar = (address) => {
   const history = useHistory();
   const inputBg = useColorModeValue('lightInputBg', 'darkInputBg');
   const mainBg = useColorModeValue('lightBody', 'darkBody');
@@ -15,6 +15,11 @@ const CreatePostBar = () => {
   const iconColor = useColorModeValue('lightIcon', 'darkIcon');
   const { authorAvatarImageUrl } = useContext(ProfileContext);
 
+  console.log('address', address);
+  let route = '/submit';
+  if (address?.address) {
+    route = `/p/${address.address}/submit`;
+  }
   return (
     <Flex bg={mainBg} borderRadius="4px" border={`1px solid ${border1}`} mb="16px" padding="8px">
       <Box
@@ -31,7 +36,7 @@ const CreatePostBar = () => {
         </Box>
       </Box>
       <Input
-        onClick={() => history.push('/submit')}
+        onClick={() => history.push(route)}
         placeholder="Create Post"
         bg={inputBg}
         border={`1px solid ${border2}`}
@@ -64,7 +69,7 @@ const CreatePostBar = () => {
         justifyContent="center"
         alignItems="center"
         width="auto"
-        onClick={() => history.push('/submit')}
+        onClick={() => history.push(route)}
       >
         <LinkIcon height="20px" width="20px" />
       </Box>

--- a/src/components/Post/CreatePost/createPostBar.jsx
+++ b/src/components/Post/CreatePost/createPostBar.jsx
@@ -15,7 +15,6 @@ const CreatePostBar = (address) => {
   const iconColor = useColorModeValue('lightIcon', 'darkIcon');
   const { authorAvatarImageUrl } = useContext(ProfileContext);
 
-  console.log('address', address);
   let route = '/submit';
   if (address?.address) {
     route = `/p/${address.address}/submit`;

--- a/src/components/Post/CreatePost/index.jsx
+++ b/src/components/Post/CreatePost/index.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import {
   Flex,
   Box,
@@ -28,6 +28,8 @@ import Avatar from '../../Avatar';
 import { getSubName } from '../../../utils/getUserName';
 
 const CreatePost = () => {
+  console.log('route', window.location.href);
+
   const { accountSubplebbits, subscriptions, subPlebbitDefData } = useContext(ProfileContext);
   const color = useColorModeValue('lightIcon', 'rgb(129, 131, 132)');
   const borderColor = useColorModeValue('borderLight', 'borderDark');
@@ -36,7 +38,7 @@ const CreatePost = () => {
   const [content, setContent] = useState('');
   const [title, setTitle] = useState('');
   const [link, setLink] = useState('');
-  const [address, setAddress] = useState(null);
+
   const [editorState, setEditorState] = useState(EditorState.createEmpty());
   const [mode, setMode] = useState('post');
   const [spoiler, setSpoiler] = useState(false);
@@ -57,7 +59,22 @@ const CreatePost = () => {
 
   const { publishComment } = useAccountsActions();
   const location = useLocation();
-
+  console.log('pathname', location?.pathname);
+  console.log('addressz', location?.pathname.match(/p\/(.*)\/submit/)[1]);
+  const options = [
+    ...mySubplebbits,
+    ...subs,
+    subPlebbitDefData.map((x) => ({
+      ...x,
+      label: getSubName(x),
+      value: x?.address,
+    })),
+  ].flat();
+  console.log('options', options);
+  const potentialSubPlebbitAddress = location?.pathname.match(/p\/(.*)\/submit/)[1];
+  const [address, setAddress] = useState(
+    options.find((x) => x.address === potentialSubPlebbitAddress)
+  );
   const onChallengeVerification = (challengeVerification, comment) => {
     // if the challengeVerification fails, a new challenge request will be sent automatically
     // to break the loop, the user must decline to send a challenge answer
@@ -130,6 +147,10 @@ const CreatePost = () => {
     }
   };
 
+  useEffect(() => {
+    console.log('address useEffect', address);
+  }, [address]);
+
   return (
     <Layout name={{ label: 'Create Post', value: location?.pathname }}>
       <Flex maxWidth="100%" justifyContent="center" margin="0 auto !important" height="100vh">
@@ -178,15 +199,7 @@ const CreatePost = () => {
                 zIndex="2"
               >
                 <DropDown2
-                  options={[
-                    ...mySubplebbits,
-                    ...subs,
-                    subPlebbitDefData.map((x) => ({
-                      ...x,
-                      label: getSubName(x),
-                      value: x?.address,
-                    })),
-                  ].flat()}
+                  options={options}
                   onChange={(value) => setAddress(value)}
                   value={address}
                   render={(data) => (

--- a/src/components/Post/CreatePost/index.jsx
+++ b/src/components/Post/CreatePost/index.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useEffect } from 'react';
+import React, { useContext, useState } from 'react';
 import {
   Flex,
   Box,
@@ -28,8 +28,6 @@ import Avatar from '../../Avatar';
 import { getSubName } from '../../../utils/getUserName';
 
 const CreatePost = () => {
-  console.log('route', window.location.href);
-
   const { accountSubplebbits, subscriptions, subPlebbitDefData } = useContext(ProfileContext);
   const color = useColorModeValue('lightIcon', 'rgb(129, 131, 132)');
   const borderColor = useColorModeValue('borderLight', 'borderDark');
@@ -59,8 +57,6 @@ const CreatePost = () => {
 
   const { publishComment } = useAccountsActions();
   const location = useLocation();
-  console.log('pathname', location?.pathname);
-  console.log('addressz', location?.pathname.match(/p\/(.*)\/submit/)[1]);
   const options = [
     ...mySubplebbits,
     ...subs,
@@ -70,8 +66,13 @@ const CreatePost = () => {
       value: x?.address,
     })),
   ].flat();
-  console.log('options', options);
-  const potentialSubPlebbitAddress = location?.pathname.match(/p\/(.*)\/submit/)[1];
+  let potentialSubPlebbitAddress = null;
+  if (location?.pathname) {
+    const matches = location?.pathname.match(/p\/(.*)\/submit/);
+    if (matches?.length > 1) {
+      potentialSubPlebbitAddress = matches[1];
+    }
+  }
   const [address, setAddress] = useState(
     options.find((x) => x.address === potentialSubPlebbitAddress)
   );
@@ -146,10 +147,6 @@ const CreatePost = () => {
       });
     }
   };
-
-  useEffect(() => {
-    console.log('address useEffect', address);
-  }, [address]);
 
   return (
     <Layout name={{ label: 'Create Post', value: location?.pathname }}>

--- a/src/views/SubPlebbit/index.jsx
+++ b/src/views/SubPlebbit/index.jsx
@@ -313,7 +313,7 @@ const SubPlebbit = ({ match }) => {
               <Flex maxW="100%" padding="20px 24px" justifyContent="center" margin="0 auto">
                 <Box width={postStyle === 'card' ? '640px' : '100%'} minWidth="0">
                   {/* Create Post Bar */}
-                  <CreatePostBar />
+                  <CreatePostBar address={subPlebbit?.address} />
                   {/* feed sort bar */}
                   <FeedSort />
                   {/* feed list */}


### PR DESCRIPTION
Rough draft of feature request `clicking create post when on a subplebbit page should automatically select that subplebbit` which is not ready to merge; just want to get input if this is the right direction.

I noticed the create post route supported addresses in the URL and went with that
https://github.com/plebbit/plebbit-react/blob/fb036ea0b67deb33f048da373f095da01d0676dd/src/App.js#L20

I pass the address to the CreatePostBar module, set the route accordingly then pull the address out of the path part in the CreatePost module. I set the address during initialization so the useEffect is pointless.

I think this would work, didnt have to access indexdb, history and global context. needs a lot of cleanup.
![Peek 2022-08-27 21-12](https://user-images.githubusercontent.com/16459104/187056643-d8875d96-1c59-469c-891e-57964763b0be.gif)

